### PR TITLE
Do not merge: evaluate ty typechecking migration

### DIFF
--- a/open_provence/modeling_open_provence_standalone.py
+++ b/open_provence/modeling_open_provence_standalone.py
@@ -16,6 +16,7 @@ checkpoints remain portable.
 from __future__ import annotations
 
 import contextlib
+import importlib
 import logging
 import math
 import os
@@ -340,9 +341,11 @@ def resolve_inference_device(device: str | torch.device | None) -> torch.device:
 
 
 try:
-    from fast_bunkai import FastBunkai
+    _fast_bunkai_module = importlib.import_module("fast_bunkai")
 except ImportError:  # pragma: no cover - optional dependency
     FastBunkai = None
+else:
+    FastBunkai = getattr(_fast_bunkai_module, "FastBunkai", None)
 
 
 _FAST_BUNKAI = None

--- a/open_provence/utils/model_architecture.py
+++ b/open_provence/utils/model_architecture.py
@@ -9,6 +9,7 @@ and BERT-like models.
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
@@ -52,9 +53,19 @@ class ModelArchitectureUtils:
 
         # Check for specific patterns
         for arch_name, patterns in ModelArchitectureUtils.ARCHITECTURE_PATTERNS.items():
-            identifiers = patterns["identifiers"]
+            identifiers_raw = patterns.get("identifiers")
+            if identifiers_raw is None:
+                continue
+            if isinstance(identifiers_raw, str):
+                identifiers_iterable = [identifiers_raw]
+            elif isinstance(identifiers_raw, Iterable):
+                identifiers_iterable = list(identifiers_raw)
+            else:
+                continue
+
             if all(
-                any(identifier in key for key in state_dict_keys) for identifier in identifiers
+                any(identifier in key for key in state_dict_keys)
+                for identifier in identifiers_iterable
             ):
                 logger.info(f"Detected {arch_name} architecture")
                 return arch_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,14 @@ include = [
     "scripts",
 ]
 
+# ty configuration
+[tool.ty.rules]
+# Temporary downgrade until torch.nn.Module.__setattr__ type stubs accept arbitrary
+# attribute values (see https://github.com/pytorch/pytorch/issues/166719 and
+# https://github.com/astral-sh/ty/issues/1460). Remove this override once
+# upstream ty/PyTorch stubs are fixed so we can re-enable the error-level check.
+unresolved-attribute = "ignore"
+
 [[tool.uv.index]]
 name = "torch-cpu"
 url = "https://download.pytorch.org/whl/cpu"
@@ -243,6 +251,7 @@ dev = [
     #    "vllm>=0.9.0.1",
     "trafilatura>=2.0.0",
     "spacy>=3.8.7",
+    "ty>=0.0.1a25",
 ]
 
 flash-attn = [

--- a/scripts/context-relevance-datasets/upload_context_relevance_to_hf.py
+++ b/scripts/context-relevance-datasets/upload_context_relevance_to_hf.py
@@ -166,35 +166,59 @@ def main() -> None:
         "Prepared dataset with %d rows (estimated size: %s)", total_rows, format_size(total_size)
     )
 
-    base_kwargs = {
-        "repo_id": args.repo_id,
-        "config_name": args.subset,
-        "commit_message": args.commit_message,
-        "commit_description": args.commit_description,
-        "private": None if args.public else True,
-        "token": args.token,
-        "revision": args.revision,
-        "max_shard_size": args.max_shard_size,
-        "num_shards": args.num_shards,
-        "embed_external_files": not args.no_embed,
-    }
-
     if args.split:
         logger.info("Uploading single split '%s'", args.split)
         target_dataset = dataset[args.split]
-        upload_kwargs = {**base_kwargs, "split": args.split}
-        logger.info("Upload parameters: %s", upload_kwargs)
+        logger.info(
+            "Upload parameters: repo_id=%s config=%s split=%s max_shard_size=%s num_shards=%s",
+            args.repo_id,
+            args.subset,
+            args.split,
+            args.max_shard_size,
+            args.num_shards,
+        )
         if args.dry_run:
             logger.info("Dry run enabled; skipping push_to_hub call.")
             return
-        commit_info = target_dataset.push_to_hub(**upload_kwargs)
+        commit_info = target_dataset.push_to_hub(
+            repo_id=args.repo_id,
+            config_name=args.subset,
+            split=args.split,
+            commit_message=args.commit_message,
+            commit_description=args.commit_description,
+            private=None if args.public else True,
+            token=args.token,
+            revision=args.revision,
+            max_shard_size=args.max_shard_size,
+            num_shards=args.num_shards,
+            embed_external_files=not args.no_embed,
+        )
     else:
         logger.info("Uploading all splits for DatasetDict")
-        logger.info("Upload parameters: %s", base_kwargs)
+        logger.info(
+            "Upload parameters: repo_id=%s config=%s max_shard_size=%s",
+            args.repo_id,
+            args.subset,
+            args.max_shard_size,
+        )
         if args.dry_run:
             logger.info("Dry run enabled; skipping push_to_hub call.")
             return
-        commit_info = dataset.push_to_hub(**base_kwargs)
+        if args.num_shards is not None:
+            logger.warning(
+                "DatasetDict.push_to_hub expects a dict for num_shards; ignoring provided --num-shards"
+            )
+        commit_info = dataset.push_to_hub(
+            repo_id=args.repo_id,
+            config_name=args.subset,
+            commit_message=args.commit_message,
+            commit_description=args.commit_description,
+            private=None if args.public else True,
+            token=args.token,
+            revision=args.revision,
+            max_shard_size=args.max_shard_size,
+            embed_external_files=not args.no_embed,
+        )
 
     logger.info("Upload complete: %s", commit_info)
 

--- a/uv.lock
+++ b/uv.lock
@@ -2205,6 +2205,7 @@ dev = [
     { name = "spacy" },
     { name = "tox-uv" },
     { name = "trafilatura" },
+    { name = "ty" },
     { name = "wandb" },
 ]
 flash-attn = [
@@ -2261,6 +2262,7 @@ dev = [
     { name = "spacy", specifier = ">=3.8.7" },
     { name = "tox-uv", specifier = ">=1.29.0" },
     { name = "trafilatura", specifier = ">=2.0.0" },
+    { name = "ty", specifier = ">=0.0.1a25" },
     { name = "wandb", specifier = ">=0.21.0" },
 ]
 flash-attn = [{ name = "flash-attn", specifier = ">=2.7.4.post1" }]
@@ -3912,6 +3914,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/24/5f/950fb373bf9c01ad4eb5a8cd5eaf32cdf9e238c02f9293557a2129b9c4ac/triton-3.3.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9999e83aba21e1a78c1f36f21bce621b77bcaa530277a50484a7cb4a822f6e43", size = 155669138, upload-time = "2025-05-29T23:39:51.771Z" },
     { url = "https://files.pythonhosted.org/packages/74/1f/dfb531f90a2d367d914adfee771babbd3f1a5b26c3f5fbc458dee21daa78/triton-3.3.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b89d846b5a4198317fec27a5d3a609ea96b6d557ff44b56c23176546023c4240", size = 155673035, upload-time = "2025-05-29T23:40:02.468Z" },
     { url = "https://files.pythonhosted.org/packages/28/71/bd20ffcb7a64c753dc2463489a61bf69d531f308e390ad06390268c4ea04/triton-3.3.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3198adb9d78b77818a5388bff89fa72ff36f9da0bc689db2f0a651a67ce6a42", size = 155735832, upload-time = "2025-05-29T23:40:10.522Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.1a25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/6b/e73bc3c1039ea72936158a08313155a49e5aa5e7db5205a149fe516a4660/ty-0.0.1a25.tar.gz", hash = "sha256:5550b24b9dd0e0f8b4b2c1f0fcc608a55d0421dd67b6c364bc7bf25762334511", size = 4403670, upload-time = "2025-10-29T19:40:23.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8f/3b/4457231238a2eeb04cba4ba7cc33d735be68ee46ca40a98ae30e187de864/ty-0.0.1a25-py3-none-linux_armv6l.whl", hash = "sha256:d35b2c1f94a014a22875d2745aa0432761d2a9a8eb7212630d5caf547daeef6d", size = 8878803, upload-time = "2025-10-29T19:39:42.243Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/fa/a328713dd310018fc7a381693d8588185baa2fdae913e01a6839187215df/ty-0.0.1a25-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:192edac94675a468bac7f6e04687a77a64698e4e1fe01f6a048bf9b6dde5b703", size = 8695667, upload-time = "2025-10-29T19:39:45.179Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e8/5707939118992ced2bf5385adc3ede7723c1b717b07ad14c495eea1e47b4/ty-0.0.1a25-py3-none-macosx_11_0_arm64.whl", hash = "sha256:949523621f336e01bc7d687b7bd08fe838edadbdb6563c2c057ed1d264e820cf", size = 8159012, upload-time = "2025-10-29T19:39:47.011Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/fb/ff313aa71602225cd78f1bce3017713d6d1b1c1e0fa8101ead4594a60d95/ty-0.0.1a25-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:94f78f621458c05e59e890061021198197f29a7b51a33eda82bbb036e7ed73d7", size = 8433675, upload-time = "2025-10-29T19:39:48.443Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/8d/cc7e7fb57215a15b575a43ed042bdd92971871e0decec1b26d2e7d969465/ty-0.0.1a25-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d9656fca8062a2c6709c30d76d662c96d2e7dbfee8f70e55ec6b6afd67b5d447", size = 8668456, upload-time = "2025-10-29T19:39:50.412Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/6d/d7bf5909ed2dcdcbc1e2ca7eea80929893e2d188d9c36b3fcb2b36532ff6/ty-0.0.1a25-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9f3bbf523b49935bbd76e230408d858dce0d614f44f5807bbbd0954f64e0f01", size = 9023543, upload-time = "2025-10-29T19:39:52.292Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/b8/72bcefb4be32e5a84f0b21de2552f16cdb4cae3eb271ac891c8199c26b1a/ty-0.0.1a25-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f13ea9815f4a54a0a303ca7bf411b0650e3c2a24fc6c7889ffba2c94f5e97a6a", size = 9700013, upload-time = "2025-10-29T19:39:57.283Z" },
+    { url = "https://files.pythonhosted.org/packages/90/0d/cf7e794b840cf6b0bbecb022e593c543f85abad27a582241cf2095048cb1/ty-0.0.1a25-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eab6e33ebe202a71a50c3d5a5580e3bc1a85cda3ffcdc48cec3f1c693b7a873b", size = 9372574, upload-time = "2025-10-29T19:40:04.532Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/71/2d35e7d51b48eabd330e2f7b7e0bce541cbd95950c4d2f780e85f3366af1/ty-0.0.1a25-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f6b9a31da43424cdab483703a54a561b93aabba84630788505329fc5294a9c62", size = 9535726, upload-time = "2025-10-29T19:40:06.548Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d3/01ecc23bbd8f3e0dfbcf9172d06d84e88155c5f416f1491137e8066fd859/ty-0.0.1a25-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0a90d897a7c1a5ae9b41a4c7b0a42262a06361476ad88d783dbedd7913edadbc", size = 9003380, upload-time = "2025-10-29T19:40:08.683Z" },
+    { url = "https://files.pythonhosted.org/packages/de/f9/cde9380d8a1a6ca61baeb9aecb12cbec90d489aa929be55cd78ad5c2ccd9/ty-0.0.1a25-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:93c7e7ab2859af0f866d34d27f4ae70dd4fb95b847387f082de1197f9f34e068", size = 8401833, upload-time = "2025-10-29T19:40:10.627Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/39/0acf3625b0c495011795a391016b572f97a812aca1d67f7a76621fdb9ebf/ty-0.0.1a25-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:4a247061bd32bae3865a236d7f8b6c9916c80995db30ae1600999010f90623a9", size = 8706761, upload-time = "2025-10-29T19:40:12.575Z" },
+    { url = "https://files.pythonhosted.org/packages/25/73/7de1648f3563dd9d416d36ab5f1649bfd7b47a179135027f31d44b89a246/ty-0.0.1a25-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1711dd587eccf04fd50c494dc39babe38f4cb345bc3901bf1d8149cac570e979", size = 8792426, upload-time = "2025-10-29T19:40:14.553Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/8a/b6e761a65eac7acd10b2e452f49b2d8ae0ea163ca36bb6b18b2dadae251b/ty-0.0.1a25-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:5f4c9b0cf7995e2e3de9bab4d066063dea92019f2f62673b7574e3612643dd35", size = 9103991, upload-time = "2025-10-29T19:40:16.332Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/25/9324ae947fcc4322470326cf8276a3fc2f08dc82adec1de79d963fdf7af5/ty-0.0.1a25-py3-none-win32.whl", hash = "sha256:168fc8aee396d617451acc44cd28baffa47359777342836060c27aa6f37e2445", size = 8387095, upload-time = "2025-10-29T19:40:18.368Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/2b/cb12cbc7db1ba310aa7b1de9b4e018576f653105993736c086ee67d2ec02/ty-0.0.1a25-py3-none-win_amd64.whl", hash = "sha256:a2fad3d8e92bb4d57a8872a6f56b1aef54539d36f23ebb01abe88ac4338efafb", size = 9059225, upload-time = "2025-10-29T19:40:20.278Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c1/f6be8cdd0bf387c1d8ee9d14bb299b7b5d2c0532f550a6693216a32ec0c5/ty-0.0.1a25-py3-none-win_arm64.whl", hash = "sha256:dde2962d448ed87c48736e9a4bb13715a4cced705525e732b1c0dac1d4c66e3d", size = 8536832, upload-time = "2025-10-29T19:40:22.014Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Do not merge – ty typecheck experiment

This PR documents what it would take to swap pyright for ty today. The diff shows the trade-offs rather than proposing something we should ship.

## What changed
- add `tool.ty` configuration (but downrank `unresolved-attribute` to `ignore` to work around `torch.nn.Module.__setattr__`)
- introduce multiple optional-dependency shims (fast_bunkai, nltk, vllm) so ty stops flagging imports
- tweak trainer utilities (`loss_fn` guard, dataset sampling arguments, `push_to_hub` calls) to satisfy ty’s stricter checks

## Why not merge
- most changes are noise introduced for ty only; they don’t catch bugs pyright was missing
- ty currently provides *less* coverage because of the `unresolved-attribute` ignore
- optional dependency code becomes harder to read/maintain compared to the original pyright-friendly version

## Next steps
Keep this branch around for reference. Once PyTorch issue 166719 / ty issue 1460 are resolved we can retry with fewer workarounds and decide whether the switch is worthwhile.