### PR TITLE
chore: add hf helper scripts

### DIFF
--- a/scripts/hf_utils/hf_model_process_check.py
+++ b/scripts/hf_utils/hf_model_process_check.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+
+from transformers import AutoModel
+
+DEFAULT_MODELS: tuple[str, ...] = (
+    "hotchpotch/open-provence-reranker-v1",
+    "hotchpotch/open-provence-reranker-xsmall-v1",
+    "hotchpotch/open-provence-reranker-large-v1",
+    "hotchpotch/open-provence-reranker-v1-gte-modernbert-base",
+)
+
+question: str = "What's your favorite Japanese food?"
+context: str = """
+Work deadlines piled up today, and I kept rambling about budget spreadsheets to my roommate.
+Next spring I'm planning a trip to Japan so I can wander Kyoto's markets and taste every regional dish I find.
+Sushi is honestly my favourite—I want to grab a counter seat and let the chef serve endless nigiri until I'm smiling through soy sauce.
+Later I remembered to water the plants and pay the electricity bill before finally getting some sleep.
+"""
+
+
+@dataclass
+class Case:
+    name: str
+    question: str | Sequence[str]
+    # allow up to 3-level nesting: queries -> docs -> sentences
+    context: str | Sequence[str] | Sequence[Sequence[str]] | Sequence[Sequence[Sequence[str]]]
+
+
+@dataclass
+class SampleResult:
+    case: str
+    sample: str
+    score: float | None
+    compression: float
+    pruned: str | None
+
+
+def build_cases() -> list[Case]:
+    questions = [question, question]
+    contexts = [context, context]
+
+    context_sentences = [line for line in context.splitlines(True) if line.strip()]
+    context_sentences_wrapped = [context_sentences]
+    contexts_nested = [context_sentences_wrapped, context_sentences_wrapped]
+
+    return [
+        Case("q=str, c=str", question, context),
+        Case("q=list[str], c=list[str]", questions, contexts),
+        Case("q=str, c=list[str] (split sentences)", question, context_sentences),
+        Case(
+            "q=str, c=list[list[str]] (split sentences, single doc)",
+            question,
+            context_sentences_wrapped,
+        ),
+        Case(
+            "q=list[str], c=list[list[str]] (split sentences per query)",
+            questions,
+            contexts_nested,
+        ),
+    ]
+
+
+def _iter_samples(
+    pruned_context, rerank_score, compression_rate
+) -> Iterable[tuple[str, str | None, float | None, float]]:
+    if not isinstance(pruned_context, list):
+        yield "", pruned_context, rerank_score, compression_rate
+        return
+
+    for idx, text in enumerate(pruned_context):
+        text_str = "\n".join(text) if isinstance(text, list) else text
+
+        score = rerank_score[idx] if isinstance(rerank_score, list) else rerank_score
+        compression = (
+            compression_rate[idx] if isinstance(compression_rate, list) else compression_rate
+        )
+
+        if isinstance(score, list):
+            score = score[0] if score else None
+        if isinstance(compression, list):
+            compression = compression[0] if compression else 0.0
+
+        yield f"#{idx}", text_str, score, float(compression)
+
+
+def run_cases(model, threshold: float, verbose: bool) -> list[SampleResult]:
+    results: list[SampleResult] = []
+    for case in build_cases():
+        result = model.process(
+            question=case.question,
+            context=case.context,
+            threshold=threshold,
+            show_progress=verbose,
+        )
+        for sample_tag, pruned, score, compression in _iter_samples(
+            result["pruned_context"],
+            result["reranking_score"],
+            result["compression_rate"],
+        ):
+            results.append(
+                SampleResult(
+                    case=case.name,
+                    sample=sample_tag,
+                    score=None if score is None else float(score),
+                    compression=float(compression),
+                    pruned=pruned if verbose else None,
+                )
+            )
+    return results
+
+
+def _format_table(rows: list[SampleResult]) -> str:
+    headers = ["Case", "Sample", "Rerank score", "Compression"]
+    data: list[list[str]] = []
+    for row in rows:
+        sample = row.sample or "-"
+        score = "-" if row.score is None else f"{row.score:.4f}"
+        compression = f"{row.compression:.2f}"
+        data.append([row.case, sample, score, compression])
+
+    col_widths = [max(len(item[i]) for item in ([headers] + data)) for i in range(len(headers))]
+
+    def fmt_row(items: Sequence[str]) -> str:
+        return " | ".join(item.ljust(col_widths[idx]) for idx, item in enumerate(items))
+
+    divider = "-+-".join("-" * width for width in col_widths)
+    lines = [fmt_row(headers), divider]
+    lines.extend(fmt_row(row) for row in data)
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Smoke-test the four HF models using the run.py sample inputs.",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="*",
+        default=DEFAULT_MODELS,
+        help="Hugging Face model IDs to load (default: README models).",
+    )
+    parser.add_argument(
+        "--threshold",
+        type=float,
+        default=0.1,
+        help="Pruning threshold passed to model.process.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Print pruned text for each sample in addition to the summary table.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    for model_id in args.models:
+        print(f"\n=== {model_id} ===")
+        model = AutoModel.from_pretrained(model_id, trust_remote_code=True)
+        model.eval()
+        rows = run_cases(model, threshold=args.threshold, verbose=args.verbose)
+
+        if args.verbose:
+            for row in rows:
+                if row.pruned is None:
+                    continue
+                print(f"\n-- {row.case} {row.sample or ''}".strip())
+                print("Pruned context:\n" + row.pruned)
+                print(f"Rerank score: {row.score}")
+                print(f"Compression: {row.compression:.2f}")
+
+        print("\n" + _format_table(rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hf_utils/update_standalone.py
+++ b/scripts/hf_utils/update_standalone.py
@@ -1,0 +1,123 @@
+"""
+Release helper: copy the local `open_provence/modeling_open_provence_standalone.py`
+into the four published HF model repos (README list) without touching git-lfs
+artifacts, then commit and push.
+
+Runbook (Nov 22, 2025):
+1) Update the standalone file locally as needed.
+2) Execute `python scripts/hf_utils/update_standalone.py`.
+   - Clones / pulls into `tmp/release_models/<model-id>` with
+     `GIT_LFS_SKIP_SMUDGE=1` to avoid LFS downloads.
+   - Copies the standalone file, commits with a dated message, and pushes.
+3) Verify: `git -C tmp/release_models/<model-id> log -1 --oneline`
+   should show `chore: update standalone file (<date>)`.
+4) Optional: run `python scripts/hf_utils/hf_model_process_check.py`
+   to smoke-test the pushed code via AutoModel.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+from collections.abc import Iterable
+from datetime import datetime
+from pathlib import Path
+
+DEFAULT_MODELS: tuple[str, ...] = (
+    "hotchpotch/open-provence-reranker-v1",
+    "hotchpotch/open-provence-reranker-xsmall-v1",
+    "hotchpotch/open-provence-reranker-large-v1",
+    "hotchpotch/open-provence-reranker-v1-gte-modernbert-base",
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+STANDALONE_SRC = REPO_ROOT / "open_provence" / "modeling_open_provence_standalone.py"
+
+
+def run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> None:
+    merged_env = os.environ.copy()
+    merged_env.update(env or {})
+    print(f"[cmd] {' '.join(cmd)} (cwd={cwd})")
+    subprocess.run(cmd, cwd=cwd, env=merged_env, check=True)
+
+
+def ensure_repo(repo_id: str, base_dir: Path, env: dict[str, str]) -> Path:
+    target_dir = base_dir / repo_id.split("/", maxsplit=1)[1]
+    if not target_dir.exists():
+        base_dir.mkdir(parents=True, exist_ok=True)
+        run(
+            ["git", "clone", f"https://huggingface.co/{repo_id}", str(target_dir)],
+            env=env,
+        )
+    else:
+        run(["git", "-C", str(target_dir), "pull", "--rebase"], env=env)
+    return target_dir
+
+
+def copy_standalone(dest_repo: Path) -> None:
+    dest = dest_repo / "modeling_open_provence_standalone.py"
+    shutil.copy2(STANDALONE_SRC, dest)
+    print(f"[copy] {STANDALONE_SRC} -> {dest}")
+
+
+def has_changes(repo_dir: Path) -> bool:
+    result = subprocess.run(
+        ["git", "-C", str(repo_dir), "status", "--porcelain"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip() != ""
+
+
+def commit_and_push(repo_dir: Path, message: str, env: dict[str, str]) -> None:
+    run(["git", "-C", str(repo_dir), "add", "modeling_open_provence_standalone.py"], env=env)
+    if not has_changes(repo_dir):
+        print("[skip] No changes to commit.")
+        return
+    run(["git", "-C", str(repo_dir), "commit", "-m", message], env=env)
+    run(["git", "-C", str(repo_dir), "push"], env=env)
+
+
+def update_models(models: Iterable[str], base_dir: Path, commit_message: str) -> None:
+    git_env = {"GIT_LFS_SKIP_SMUDGE": "1"}
+    for repo_id in models:
+        print(f"\n=== Updating {repo_id} ===")
+        repo_dir = ensure_repo(repo_id, base_dir, git_env)
+        copy_standalone(repo_dir)
+        commit_and_push(repo_dir, commit_message, git_env)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync modeling_open_provence_standalone.py into HF model repos without git-lfs.",
+    )
+    parser.add_argument(
+        "--models",
+        nargs="*",
+        default=DEFAULT_MODELS,
+        help="Hugging Face model IDs to update (defaults to the four models in README.md).",
+    )
+    parser.add_argument(
+        "--base-dir",
+        type=Path,
+        default=Path("tmp/release_models"),
+        help="Local directory for cloning HF model repos.",
+    )
+    parser.add_argument(
+        "--message",
+        default=f"chore: update standalone file ({datetime.now().date().isoformat()})",
+        help="Git commit message to use for pushes.",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    update_models(models=args.models, base_dir=args.base_dir, commit_message=args.message)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Why: keep the four HF checkpoints' standalone file in sync without LFS downloads and add a one-command smoke test to catch regressions in the published code paths.
- Add update_standalone.py to clone into tmp/release_models/<model>, copy modeling_open_provence_standalone.py, and commit/push with git-lfs skipped and a dated message.
- Add hf_model_process_check.py to rerun the README/run.py sample cases across the four models, with a verbose mode to print pruned text for debugging.

## Testing
- uv run tox run-parallel
- python scripts/hf_utils/hf_model_process_check.py
